### PR TITLE
design: 레이아웃 구현

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,21 @@
+import { theme } from '@/styles/theme';
+import { styled } from 'styled-components';
+
+type Props = {
+  back?: boolean;
+};
+
+const Header = ({ back }: Props) => {
+  return back ? <Wrapper back>돌아가기</Wrapper> : <Wrapper>헤더</Wrapper>;
+};
+
+export default Header;
+
+const Wrapper = styled.div<{ back?: boolean }>`
+  width: 100%;
+  height: 68px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  ${(props) => (props.back ? '' : theme.shadows.large)}
+`;

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+import { styled } from 'styled-components';
+import { theme } from '@/styles/theme';
+
+type Props = {
+  children: ReactNode;
+  className?: React.ComponentProps<'div'>['className'];
+};
+
+const Layout = ({ children, ...rest }: Props) => {
+  return (
+    <Wrapper {...rest}>
+      <main>{children}</main>
+    </Wrapper>
+  );
+};
+
+export default Layout;
+
+const Wrapper = styled.main`
+  max-width: 800px;
+  height: 100vh;
+  margin: 0 auto;
+
+  background-color: ${theme.colors.white};
+  ${theme.shadows.large};
+`;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,14 +3,28 @@ import notoSansKr from '@/styles/font';
 import GlobalStyle from '@/styles/global-styles';
 import { ThemeProvider } from 'styled-components';
 import { theme } from '@/styles/theme';
+import Layout from '@/components/layout';
 
-export default function App({ Component, pageProps }: AppProps) {
+import type { ReactElement, ReactNode } from 'react';
+import type { NextPage } from 'next';
+
+type NextPageWithLayout = NextPage & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
+
+export default function App({ Component, pageProps }: AppPropsWithLayout) {
+  const getLayout = Component.getLayout || ((page) => <Layout>{page}</Layout>);
+
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <main className={notoSansKr.className}>
-        <Component {...pageProps} />
-      </main>
+      <Layout className={notoSansKr.className}>
+        {getLayout(<Component {...pageProps} />)}
+      </Layout>
     </ThemeProvider>
   );
 }

--- a/src/pages/test/header/back.tsx
+++ b/src/pages/test/header/back.tsx
@@ -1,0 +1,17 @@
+import Layout from '@/components/layout';
+import Header from '@/components/layout/Header';
+
+const BackHeader = () => {
+  return <h1>돌아가기 헤더</h1>;
+};
+
+BackHeader.getLayout = function getLayout(page: React.ReactElement) {
+  return (
+    <Layout>
+      <Header back />
+      {page}
+    </Layout>
+  );
+};
+
+export default BackHeader;

--- a/src/pages/test/header/index.tsx
+++ b/src/pages/test/header/index.tsx
@@ -1,0 +1,17 @@
+import Layout from '@/components/layout';
+import Header from '@/components/layout/Header';
+
+const TestHeader = () => {
+  return <h1>헤더 있음</h1>;
+};
+
+TestHeader.getLayout = function getLayout(page: React.ReactElement) {
+  return (
+    <Layout>
+      <Header />
+      {page}
+    </Layout>
+  );
+};
+
+export default TestHeader;

--- a/src/pages/test/header/none.tsx
+++ b/src/pages/test/header/none.tsx
@@ -1,0 +1,8 @@
+import Layout from '@/components/layout';
+import Header from '@/components/layout/Header';
+
+const NoneHeader = () => {
+  return <h1>헤더 없음</h1>;
+};
+
+export default NoneHeader;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -14,10 +14,30 @@ const shadows = {
   small: `box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.16)`,
 };
 
+const breakpoints = {
+  mobile1: '375px',
+  mobile2: '425px',
+  tablet: '768px',
+  laptop: '1024px',
+  desktop: '1440px',
+} as const;
+
+const mediaQuery = (maxWidth: string) => `@media (max-width: ${maxWidth})`;
+
+const media = {
+  mobile1: mediaQuery(breakpoints.mobile1),
+  mobile2: mediaQuery(breakpoints.mobile2),
+  tablet: mediaQuery(breakpoints.tablet),
+  laptop: mediaQuery(breakpoints.laptop),
+  desktop: mediaQuery(breakpoints.desktop),
+} as const;
+
 export type ColorsTypes = typeof colors;
 export type ShadowsTypes = typeof shadows;
+export type MediaTypes = typeof media;
 
 export const theme: DefaultTheme = {
   colors,
   shadows,
+  media,
 };


### PR DESCRIPTION
## ✏️ 한 줄 요약
레이아웃 구현

## 📝 상세 내용
- 화면 사이즈
  - 모바일일 경우: 화면이 채워지게
  - 데스크탑일 경우: 화면 정중앙에 배치
- 헤더
  - 헤더가 없는 경우
  - 메인 페이지
  - 돌아가기 버튼
- 테스트 페이지 생성
  - 헤더가 없는 경우: `/test/header/none`
  - 기본 헤더(그림자o): `/test/header`
  - 돌아가기 버튼(그림자x): `/test/header/back`

## 📚 참고 레퍼런스

## ⚠️ 참고 사항

## 🖥️ 스크린샷
- 피그마 디자인

| 헤더 x | 메인페이지 | 돌아가기 버튼|
| -- | -- | -- |
| <img src="https://github.com/HalamLee/Interviz/assets/87893624/a9454c1b-7671-4aed-9050-e6799a4c9452"> | <img src="https://github.com/HalamLee/Interviz/assets/87893624/53792524-c0a4-4335-8664-8e0fbc2aa83e"> | <img src="https://github.com/HalamLee/Interviz/assets/87893624/b5569787-35bd-4fc8-9ca9-5766ac9c64a3"> |

<br><br>

- 구현

https://github.com/HalamLee/Interviz/assets/87893624/f653855a-c7db-4ee8-be96-dddc40edcf69

| 헤더가 없는 경우: `/test/header/none` | 기본 헤더(그림자o): `/test/header` | 돌아가기 버튼(그림자x): `/test/header/back`|
| -- | -- | -- |
| <img src="https://github.com/HalamLee/Interviz/assets/87893624/199f7a6a-5eec-40d5-8c9d-cbf338f12e83"> | <img src="https://github.com/HalamLee/Interviz/assets/87893624/09f7c161-a45b-4568-a37c-2bfb25a4c846"> | <img src="https://github.com/HalamLee/Interviz/assets/87893624/5330db9a-2983-4b8f-9a36-ab8e308cc0b8"> |




