### PR TITLE
feat: 버튼 컴포넌트 작성

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,0 +1,49 @@
+import notoSansKr from '@/styles/font';
+import { ColorsTypes, theme } from '@/styles/theme';
+import { css, styled } from 'styled-components';
+
+type Props = {
+  isSmall?: boolean;
+  content: string;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  color: keyof ColorsTypes;
+};
+
+const Button = ({ isSmall, content, onClick, color }: Props) => {
+  return (
+    <Wrapper isSmall={isSmall} onClick={onClick} color={color}>
+      {content}
+    </Wrapper>
+  );
+};
+
+export default Button;
+
+const Wrapper = styled.button<{ color: keyof ColorsTypes; isSmall?: boolean }>`
+  /* 공통 */
+  ${theme.center}
+  ${notoSansKr.style}
+  font-weight: 500;
+  color: ${theme.colors.white};
+  background-color: ${(props) => theme.colors[props.color]};
+  cursor: pointer;
+  border: none;
+  outline: none;
+
+  /* big */
+  width: 150px;
+  height: 50px;
+  border-radius: 5px;
+  ${theme.shadows.btnBig};
+  font-size: 16px;
+
+  /* small => isSmall props 사용 */
+  ${(props) =>
+    props.isSmall &&
+    css`
+      width: 74px;
+      height: 30px;
+      border-radius: 3px;
+      font-size: 10px;
+    `}
+`;

--- a/src/pages/test/button.tsx
+++ b/src/pages/test/button.tsx
@@ -1,0 +1,30 @@
+import Button from '@/components/button/Button';
+import { theme } from '@/styles/theme';
+import { styled } from 'styled-components';
+
+const ButtonTest = () => {
+  const handleClick = () => {
+    alert('클릭');
+  };
+
+  return (
+    <Wrapper>
+      <Button
+        isSmall
+        content={'작은 버튼'}
+        onClick={handleClick}
+        color={'main'}
+      />
+      <Button content={'큰 버튼'} onClick={handleClick} color={'sub'} />
+    </Wrapper>
+  );
+};
+
+export default ButtonTest;
+
+const Wrapper = styled.div`
+  padding-top: 50px;
+  width: 400px;
+  ${theme.center};
+  gap: 20px;
+`;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -12,7 +12,15 @@ const colors = {
 const shadows = {
   large: `box-shadow: 0px 84px 34px rgba(0, 0, 0, 0.01), 0px 47px 28px rgba(0, 0, 0, 0.03), 0px 21px 21px rgba(0, 0, 0, 0.05), 0px 5px 12px rgba(0, 0, 0, 0.06), 0px 0px 0px rgba(0, 0, 0, 0.06)`,
   small: `box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.16)`,
+  btnBig: `box-shadow: 0px 4px 4px rgba(50, 50, 71, 0.08), 0px 4px 8px rgba(50, 50, 71, 0.06)`,
+  btnSmall: `box-shadow: 0px 1.83814px 1.83814px rgba(50, 50, 71, 0.08), 0px 1.83814px 3.67628px rgba(50, 50, 71, 0.06)`,
 };
+
+const center = `
+display:flex;
+justify-content: center;
+align-items: center;
+`;
 
 const breakpoints = {
   mobile1: '375px',
@@ -40,4 +48,5 @@ export const theme: DefaultTheme = {
   colors,
   shadows,
   media,
+  center,
 };


### PR DESCRIPTION
## ✏️ 한 줄 요약
버튼 컴포넌트 작성

## 📝 상세 내용 
- theme에 버튼에서 사용하는 `shadow` 값 추가
- theme에 flex로 가로,세로 정중앙에 배치하는 `center` 추가
- 기본 값은 큰 사이즈 버튼으로 스타일링
- `isSmall` props를 넘겨주면 작은 버튼으로 스타일링
- `/test/button` 에 테스트 페이지 생성

## 📚 참고 레퍼런스

## ⚠️ 참고 사항

## 🖥️ 스크린샷
### 피그마 디자인

- size='big'

<table>
  <tr>
    <td><img src="https://github.com/HalamLee/Interviz/assets/87893624/1f5e77d9-3e4c-4594-8d63-bb182f9646e3"></td>
    <td><img src="https://github.com/HalamLee/Interviz/assets/87893624/69773d7a-37d1-4fe2-918a-eb94d65f9ebc"></td>
    <td><img src="https://github.com/HalamLee/Interviz/assets/87893624/596491a3-b787-471f-aeb8-cfec2a77a5c5"></td>
  </tr>

</table><br>


- size='small'

<table>
<tr>
    <td><img src="https://github.com/HalamLee/Interviz/assets/87893624/5db015c6-42b2-427d-b7b0-99ce5bee2c26"></td>
    <td><img src="https://github.com/HalamLee/Interviz/assets/87893624/a6fdefba-afc2-4086-beda-27f09cd28185"></td>
  </tr>
</table>


### 구현
![image](https://github.com/HalamLee/Interviz/assets/87893624/392056cf-8f2d-44d7-9c8c-0cbe2430559b)
