### PR TITLE
feat: SplashScreen을 띄운적 있는지 판별 후 없다면 2초 띄우고 사이트 페이지 보여주기

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,7 +6,9 @@ import { theme } from '@styles/theme';
 import Layout from '@components/layout';
 
 import type { ReactElement, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 import type { NextPage } from 'next';
+import SplashScreen from '@components/splash-screen';
 
 type NextPageWithLayout = NextPage & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -17,7 +19,39 @@ type AppPropsWithLayout = AppProps & {
 };
 
 export default function App({ Component, pageProps }: AppPropsWithLayout) {
+  const [isHydrated, setIsHydrated] = useState(false);
+  const [showSplash, setShowSplash] = useState(true);
+
+  useEffect(() => {
+    setIsHydrated(true);
+
+    // 2초 후에 스플래시 스크린을 숨김
+    const timer = setTimeout(() => {
+      setShowSplash(false);
+      window.sessionStorage.setItem('isSplashDisplayed', 'true');
+    }, 2000);
+
+    return () => clearTimeout(timer); // 컴포넌트가 unmount되면 타이머를 클리어
+  }, []);
+
   const getLayout = Component.getLayout || ((page) => <Layout>{page}</Layout>);
+
+  if (!isHydrated) {
+    return null; // 서버에서는 아무것도 렌더링하지 않도록 함
+  }
+
+  if (typeof window !== 'undefined') {
+    if (window.sessionStorage.getItem('isSplashDisplayed') !== 'true') {
+      return (
+        <>
+          <GlobalStyle />
+          <Layout>
+            <SplashScreen />
+          </Layout>
+        </>
+      );
+    }
+  }
 
   return (
     <ThemeProvider theme={theme}>


### PR DESCRIPTION
## ✏️ 한 줄 요약
SplashScreen 띄우기

## 📝 상세 내용 
- 세션 스토리지를 이용해서 SplashScreen을 띄웠었는지 판별 후, 처음이라면 2초 띄우고 사이트 보여주기

## 📚 참고 레퍼런스
[Next js에서 sessionStorage is not defined 문제 해결 방법](https://brick-house.tistory.com/18)
## ⚠️ 참고 사항

## 🖥️ 스크린샷

https://github.com/HalamLee/Interviz/assets/87893624/6d440dde-99a7-4642-9c99-83f3b6571997

https://github.com/HalamLee/Interviz/assets/87893624/008d73e5-5b26-4812-b433-06014df8fc54

