### PR TITLE
feat: 기존 Comment 페이지 Comment 컴포넌트 분리후 dynamic import로 CSR 렌더링 #52

### DIFF
--- a/src/components/comment/index.tsx
+++ b/src/components/comment/index.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react';
+import { styled } from 'styled-components';
+const Comment = () => {
+  const commentsRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const scriptElem = document.createElement('script');
+    scriptElem.src = 'https://utteranc.es/client.js';
+    scriptElem.async = true;
+    scriptElem.setAttribute('repo', 'HalamLee/Interviz');
+    scriptElem.setAttribute('issue-term', 'title');
+    scriptElem.setAttribute('theme', 'github-light');
+    scriptElem.setAttribute('label', '💬 comment');
+    scriptElem.crossOrigin = 'anonymous';
+
+    commentsRef.current?.appendChild(scriptElem);
+  }, []);
+
+  return <CommentWrapper ref={commentsRef} />;
+};
+
+export default Comment;
+
+const CommentWrapper = styled.section`
+  width: 100%;
+`;

--- a/src/pages/comment.tsx
+++ b/src/pages/comment.tsx
@@ -3,31 +3,28 @@ import Header from '@components/layout/Header';
 import { theme } from '@styles/theme';
 import Head from 'next/head';
 import { styled } from 'styled-components';
+import dynamic from 'next/dynamic';
 
-const Comment = () => {
+const DynamicComment = dynamic(
+  () => import('@components/comment').then((mod) => mod.default),
+  {
+    ssr: false, // SSR을 비활성화하여 클라이언트 측에서만 렌더링되도록 설정
+  }
+);
+
+const CommentPage = () => {
   return (
     <Wrapper>
-      <section
-        ref={(elem) => {
-          if (!elem) {
-            return;
-          }
-          const scriptElem = document.createElement('script');
-          scriptElem.src = 'https://utteranc.es/client.js';
-          scriptElem.async = true;
-          scriptElem.setAttribute('repo', 'HalamLee/Interviz');
-          scriptElem.setAttribute('issue-term', 'title');
-          scriptElem.setAttribute('theme', 'github-light');
-          scriptElem.setAttribute('label', '💬 comment');
-          scriptElem.crossOrigin = 'anonymous';
-          elem.appendChild(scriptElem);
-        }}
-      />
+      <Content>
+        <h1>코멘트를 남겨주세요!</h1>
+        <span>피드백, 원하는 기능, 하고 싶은 말.. 등등 모두 환영합니다 🙌🏻</span>
+      </Content>
+      <DynamicComment />
     </Wrapper>
   );
 };
 
-Comment.getLayout = function getLayout(page: React.ReactElement) {
+CommentPage.getLayout = function getLayout(page: React.ReactElement) {
   return (
     <Layout>
       <Head>
@@ -39,14 +36,29 @@ Comment.getLayout = function getLayout(page: React.ReactElement) {
   );
 };
 
-export default Comment;
+export default CommentPage;
 
 const Wrapper = styled.div`
   width: 100%;
-  height: calc(100vh - 50px);
+  min-height: calc(100vh - 50px);
   background-color: ${theme.colors.white};
   ${theme.center};
   gap: 40px;
   padding: 30px 0;
   box-sizing: border-box;
+`;
+
+const Content = styled.div`
+  height: 300px;
+  ${theme.center};
+  gap: 40px;
+  margin-bottom: 20px;
+
+  h1 {
+    font-size: 48px;
+  }
+
+  span {
+    font-size: 20px;
+  }
 `;


### PR DESCRIPTION
## ✏️ 한 줄 요약
피드백 받을 수 있는 comment 페이지 생성

## 📝 상세 내용 
comment 페이지 생성 후 메인 페이지에서 연결

## 📚 참고 레퍼런스
- [공식 사용법 - utterances 🔮](https://utteranc.es/)
- [Next.js기반 blog에 uttarences 추가하기](https://grap3fruit.dev/blog/Next.js%EA%B8%B0%EB%B0%98-blog%EC%97%90-uttarences-%EC%B6%94%EA%B0%80%ED%95%98%EA%B8%B0)
- [공식 문서 - next/dynamic](https://nextjs.org/docs/pages/building-your-application/optimizing/lazy-loading#nextdynamic)
## ⚠️ 참고 사항

## 🖥️ 스크린샷
| 메인 페이지 | 코멘트 페이지 | 로그인 후 | 댓글 작성 |
| -- | -- | -- | -- |
| <img src="https://github.com/HalamLee/Interviz/assets/87893624/2013a582-8bc4-4383-a521-db24c4041c40"> | <img src="https://github.com/HalamLee/Interviz/assets/87893624/aacd975e-d9b5-4717-808e-72c7a121bc62"> | <img src="https://github.com/HalamLee/Interviz/assets/87893624/56101191-f638-4958-8e54-dfef1c399be1"> |  <img src="https://github.com/HalamLee/Interviz/assets/87893624/fc19bf06-e96a-49cc-a32f-3fec3f2ae114"> | 


